### PR TITLE
Remove custom GamePad code

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Available preprocessor flags in this branch (define these in NintendontVersion.h
         * Home -> Start (if `LI_NOEXIT` is used)
         * Select -> Z
 * `LI_SHOULDER_DIRECT`: tweaks the button mappings on certain controllers
-    * Classic Controller / Classic Controller Pro:
+    * Classic Controller / Classic Controller Pro / Wii U GamePad:
         * L -> L (analog passthrough)
         * R -> R (analog passthrough)
         * ZL -> Y

--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@ Available preprocessor flags in this branch (define these in NintendontVersion.h
 
 * `LI_XBOX360`: includes all extra code from https://github.com/revvv/Nintendont-XBOX360 to support Xbox 360 controllers and others (see below - note that some supporting code is included either way)
 * `LI_NONUNCHUK`: removes Nunchuk support
-* `LI_GAMEPADASCCPRO`: removes Wii U GamePad mapping code and instead reuses the Classic Controller Pro code path
 * `LI_NOSWAP`: removes the controller shortcuts that allow you to swap buttons (Y/B vs. B/A)
 * `LI_NOEXIT`: removes the ability to exit Nintendont without turning off or resetting the console
 * `LI_NORESET`: removes the ability to reset the game with a controller button combo (at least on certain controllers)
@@ -18,7 +17,7 @@ Available preprocessor flags in this branch (define these in NintendontVersion.h
         * ZR -> half R press (0x7F)
         * Home -> Start (if `LI_NOEXIT` is used)
         * Select -> Z
-    * Classic Controller Pro:
+    * Classic Controller Pro / Wii U GamePad:
         * ZL -> full L press (0xFF)
         * ZR -> full R press (0xFF)
         * L -> half L press (0x7F)
@@ -44,7 +43,8 @@ You'll also want to make sure the devkitpro folder with libwinpthread-1.dll is i
 ### Custom controls
 
 When the preprocessor flag `LI_CUSTOM_CONTROLS` is enabled, the following changes will be made to
-Classic Controller and Classic Controller Pro button mappings:
+Classic Controller and Classic Controller Pro button mappings. (Mappings for other controllers,
+like the Wii U GamePad and GameCube Controller, will not be changed.)
 
 * The Legend of Zelda: Four Swords Adventures
     * D-pad unmapped

--- a/common/include/NintendontVersion.h
+++ b/common/include/NintendontVersion.h
@@ -30,7 +30,6 @@
 #endif
 
 #define LI_ANALOG_SHOULDER_FULL
-#define LI_GAMEPADASCCPRO
 #define LI_NOSWAP
 #define LI_NOEXIT
 #define LI_NORESET

--- a/loader/source/ppc/PADReadGC/source/PADReadGC.c
+++ b/loader/source/ppc/PADReadGC/source/PADReadGC.c
@@ -491,6 +491,28 @@ u32 PADRead(u32 calledByGame)
 
 		if (drcbutton & WIIDRC_BUTTON_MINUS)
 			button |= PAD_TRIGGER_Z;
+#elif defined LI_SHOULDER_DIRECT
+		if (drcbutton & WIIDRC_BUTTON_L) {
+			button |= PAD_TRIGGER_L;
+			Pad[WiiUGamepadSlot].triggerLeft = 0xFF;
+		}
+		else {
+			Pad[WiiUGamepadSlot].triggerLeft = 0;
+		}
+
+		if (drcbutton & WIIDRC_BUTTON_R) {
+			button |= PAD_TRIGGER_R;
+			Pad[WiiUGamepadSlot].triggerRight = 0xFF;
+		}
+		else {
+			Pad[WiiUGamepadSlot].triggerRight = 0;
+		}
+
+		if (drcbutton & WIIDRC_BUTTON_ZL)
+			button |= PAD_TRIGGER_Y;
+
+		if (drcbutton & WIIDRC_BUTTON_ZR)
+			button |= PAD_TRIGGER_Z;
 #else
 		//also sets left analog trigger
 		if(drcbutton & WIIDRC_BUTTON_ZL)

--- a/loader/source/ppc/PADReadGC/source/PADReadGC.c
+++ b/loader/source/ppc/PADReadGC/source/PADReadGC.c
@@ -439,39 +439,6 @@ u32 PADRead(u32 calledByGame)
 		//check for console shutdown request
 		if(i2cdata[1] & 0x80) goto DoShutdown;
 
-#ifdef LI_GAMEPADASCCPRO
-		struct BTPadCont simulatedPad;
-		simulatedPad.used = C_CCP;
-
-		s8 tmp_stick8; s16 tmp_stick16;
-		_DRC_BUILD_TMPSTICK(i2cdata[4]);
-		simulatedPad.xAxisL = tmp_stick8;
-		_DRC_BUILD_TMPSTICK(i2cdata[5]);
-		simulatedPad.yAxisL = tmp_stick8;
-		_DRC_BUILD_TMPSTICK(i2cdata[6]);
-		simulatedPad.xAxisR = tmp_stick8;
-		_DRC_BUILD_TMPSTICK(i2cdata[7]);
-		simulatedPad.yAxisR = tmp_stick8;
-
-		u16 drcbutton = (i2cdata[2] << 8) | (i2cdata[3]);
-		if (drcbutton & WIIDRC_BUTTON_UP) simulatedPad.button |= BT_DPAD_UP;
-		if (drcbutton & WIIDRC_BUTTON_DOWN) simulatedPad.button |= BT_DPAD_DOWN;
-		if (drcbutton & WIIDRC_BUTTON_LEFT) simulatedPad.button |= BT_DPAD_LEFT;
-		if (drcbutton & WIIDRC_BUTTON_RIGHT) simulatedPad.button |= BT_DPAD_RIGHT;
-		if (drcbutton & WIIDRC_BUTTON_A) simulatedPad.button |= BT_BUTTON_A;
-		if (drcbutton & WIIDRC_BUTTON_B) simulatedPad.button |= BT_BUTTON_B;
-		if (drcbutton & WIIDRC_BUTTON_X) simulatedPad.button |= BT_BUTTON_X;
-		if (drcbutton & WIIDRC_BUTTON_Y) simulatedPad.button |= BT_BUTTON_Y;
-		if (drcbutton & WIIDRC_BUTTON_L) simulatedPad.button |= BT_TRIGGER_L;
-		if (drcbutton & WIIDRC_BUTTON_R) simulatedPad.button |= BT_TRIGGER_R;
-		if (drcbutton & WIIDRC_BUTTON_ZL) simulatedPad.button |= BT_TRIGGER_ZL;
-		if (drcbutton & WIIDRC_BUTTON_ZR) simulatedPad.button |= BT_TRIGGER_ZR;
-		if (drcbutton & WIIDRC_BUTTON_PLUS) simulatedPad.button |= BT_BUTTON_START;
-		if (drcbutton & WIIDRC_BUTTON_MINUS) simulatedPad.button |= BT_BUTTON_SELECT;
-		if (drcbutton & WIIDRC_BUTTON_HOME) simulatedPad.button |= BT_BUTTON_HOME;
-
-		HandleClassicController(simulatedPad, &Pad[WiiUGamepadSlot]);
-#else
 		//Start out mapping buttons first
 		u16 button = 0;
 		u16 drcbutton = (i2cdata[2]<<8) | (i2cdata[3]);
@@ -499,7 +466,7 @@ u32 PADRead(u32 calledByGame)
 		if(drcbutton & WIIDRC_BUTTON_RIGHT) button |= PAD_BUTTON_RIGHT;
 		if(drcbutton & WIIDRC_BUTTON_UP) button |= PAD_BUTTON_UP;
 		if(drcbutton & WIIDRC_BUTTON_DOWN) button |= PAD_BUTTON_DOWN;
-#ifdef LI_SHOULDER
+#if defined LI_SHOULDER
 		if (drcbutton & WIIDRC_BUTTON_ZL) {
 			button |= PAD_TRIGGER_L;
 			Pad[WiiUGamepadSlot].triggerLeft = 0xFF;
@@ -582,7 +549,6 @@ u32 PADRead(u32 calledByGame)
 		Pad[WiiUGamepadSlot].substickX = tmp_stick8;
 		_DRC_BUILD_TMPSTICK(i2cdata[7]);
 		Pad[WiiUGamepadSlot].substickY = tmp_stick8;
-#endif
 	}
 	else
 	{

--- a/loader/source/ppc/PADReadGC/source/PADReadGC.c
+++ b/loader/source/ppc/PADReadGC/source/PADReadGC.c
@@ -509,7 +509,7 @@ u32 PADRead(u32 calledByGame)
 		}
 
 		if (drcbutton & WIIDRC_BUTTON_ZL)
-			button |= PAD_TRIGGER_Y;
+			button |= PAD_BUTTON_Y;
 
 		if (drcbutton & WIIDRC_BUTTON_ZR)
 			button |= PAD_TRIGGER_Z;


### PR DESCRIPTION
1. Revert Wii U GamePad behavior back to what upstream Nintendont does
2. Add a check for `LI_SHOULDER_DIRECT` (gray build) for the GamePad

This removes custom per-game controls from the GamePad - unfortunately the code I put in to add them just doesn't seem to work (at least not anymore).